### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,8 @@ export interface Props {
 	```
 	*/
 	readonly fallback?: boolean;
+	
+	children?: React.ReactNode;
 }
 
 /**


### PR DESCRIPTION
Add explicit `children` prop since React.FC does not expose it anymore (since React 18).
```
	<Link url="https://sindresorhus.com">
		My <Color cyan>Website</Color>
	</Link>
```
gives the following error: 
```
error TS2322: Type '{ children: Element; url: string; }' is not assignable to type 'IntrinsicAttributes & Props'.
  Property 'children' does not exist on type 'IntrinsicAttributes & Props'.
```