### PR TITLE
fix: remove defaultProps as it's now deprecated

### DIFF
--- a/source/index.tsx
+++ b/source/index.tsx
@@ -78,8 +78,4 @@ Link.propTypes = {
 	fallback: PropTypes.bool, // eslint-disable-line react/boolean-prop-naming
 };
 
-Link.defaultProps = {
-	fallback: true,
-};
-
 export default Link;


### PR DESCRIPTION
The goal is to remove the huge Warning when using this component in ink application.

I saw the pull request you just release one month ago, but it does not fix the problem at all.

https://github.com/sindresorhus/ink-link/pull/17/files

Removing these line fix the issue.

Thanks for your job! 🤟